### PR TITLE
Don't show main window on startup

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -26,8 +26,7 @@ int main(int argc, char *argv[])
     meow::App app;
 
     meow::ui::main_window::Window w;
-    w.show();
-
+    
     w.showSessionManagerDialog();
 
     return a.exec();

--- a/ui/session_manager/window.cpp
+++ b/ui/session_manager/window.cpp
@@ -401,6 +401,8 @@ void Window::openCurrentSession()
     if (opened) {
         accept(); // close this dialog
     }
+
+    _mainWindow->show();
 }
 
 void Window::selectSessionAt(int rowIndex)


### PR DESCRIPTION
I think there's no need to show unclickable blank main window on startup.

Like in heidisql it would be also nice to hide the main window when user disconnected and there are no more active connections left. But I couldn't get that to work yet. I tried to use `this->hide()` in this if statement but hide event probably is overwritten and it downd't work. Also tried to use `emit hide()` but it crashes half of the time. 
https://github.com/ragnar-lodbrok/meow-sql/blob/05180df1d7178257f1fa5da4aabae320e9ffe0d1/ui/main_window/main_window.cpp#L123-L125
Any ideas how to hide the main window on no opened connections?