### PR TITLE
Fix cmake unable to find PostgreSQL includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,7 @@ if (WIN32)
 
 endif()
 
+set(PostgreSQL_TYPE_INCLUDE_DIR "${PostgreSQL_TYPE_INCLUDE_DIR};/usr/include/postgresql/")
 
 find_package(PostgreSQL REQUIRED)
 


### PR DESCRIPTION
I'm getting cmake errors unable to find PostgeSQL with `cmake ..`
```-- The C compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
  Could NOT find PostgreSQL (missing: PostgreSQL_TYPE_INCLUDE_DIR) (found
  version "13.2")
Call Stack (most recent call first):
  /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:458 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.18/Modules/FindPostgreSQL.cmake:247 (find_package_handle_standard_args)
  CMakeLists.txt:383 (find_package)
```

I have libs installed on my debian buster/sid system
```
libpq-dev
postgresql-server-dev-13
postgresql-server-dev-all
```

The solution was due to missing env variable for PostgeSQL
```bash
$ cmake .. -DPostgreSQL_TYPE_INCLUDE_DIR=/usr/include/postgresql/
```
or now in cmake
```cmake
set(PostgreSQL_TYPE_INCLUDE_DIR "${PostgreSQL_TYPE_INCLUDE_DIR};/usr/include/postgresql/")
```

Now cmake succeeds
```
-- The C compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PostgreSQL: /usr/lib/x86_64-linux-gnu/libpq.so (found version "13.2") 
PostgreSQL_VERSION_STRING = 13.2
PostgreSQL_INCLUDE_DIRS = /usr/include/postgresql;/usr/include/postgresql
PostgreSQL_LIBRARY_DIRS = /usr/lib/x86_64-linux-gnu
PostgreSQL_LIBRARIES = /usr/lib/x86_64-linux-gnu/libpq.so
-- Configuring done
-- Generating done
-- Build files have been written to: /whatever
```